### PR TITLE
Upgrade node-pty to ^0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Lily Scott <me@suchipi.com>",
   "license": "MIT",
   "dependencies": {
-    "node-pty": "^0.8.0",
+    "node-pty": "^0.9.0",
     "strip-ansi": "^5.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -130,15 +130,27 @@ const spawn = (cmd, argsOrOptions, passedOptions) => {
   };
 
   stdout.setEncoding("utf-8");
-  stdout.on("data", (data) => {
+
+  const handleStdoutData = (data) => {
     runContext.result.stdout += data;
     outputContainsBuffer += data;
     debugLog(`STDOUT: ${data.toString()}`);
     checkForPendingOutputRequestsToResolve();
-  });
+  };
+
+  if (stdout.onData) {
+    // the pty instance returned by node-pty
+    // requires attaching handlers differently
+    stdout.onData(handleStdoutData);
+  } else {
+    stdout.on('data', handleStdoutData);
+  }
 
   if (stderr) {
     stderr.setEncoding("utf-8");
+
+    // this is never a pty instance,
+    // so we don't need to deal with onData here:
     stderr.on("data", (data) => {
       runContext.result.stderr += data;
       outputContainsBuffer += data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3327,10 +3327,10 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
-  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
+nan@^2.14.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 nan@^2.9.2:
   version "2.12.1"
@@ -3404,12 +3404,12 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pty@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.8.0.tgz#08bccb633f49e2e3f7245eb56ea6b40f37ccd64f"
-  integrity sha512-g5ggk3gN4gLrDmAllee5ScFyX3YzpOC/U8VJafha4pE7do0TIE1voiIxEbHSRUOPD1xYqmY+uHhOKAd3avbxGQ==
+node-pty@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.9.0.tgz#8f9bcc0d1c5b970a3184ffd533d862c7eb6590a6"
+  integrity sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==
   dependencies:
-    nan "2.10.0"
+    nan "^2.14.0"
 
 node-releases@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
- Upgrading node-pty to support Node 12
- Fixed deprecated `.on('data', cb)` call to `.onData(cb)` (see https://github.com/microsoft/node-pty/releases/tag/0.9.0)
- `yarn test` passed all tests locally.